### PR TITLE
Remove engine specifications to open up the package for other node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
       }
     ]
   },
-  "engines": {
-    "node": "7.4.0"
-  },
   "dependencies": {
     "ajv": "^6.12.2",
     "async": "2.6.1",


### PR DESCRIPTION
I removed the engine restriction and functionality of the application worked fine on my project with version `10.17.0`

IMO it's unnecessary to confine this package to one specific version of node, especially a legacy version, because it makes the package unusable for 99% of people using yarn (since they are unlikely to have the exact version specified in their frontend React project and `yarn add monero-javascript` will therefore fail).

I've submitted this small PR to remove this restriction. If there's some reason it's not acceptable please let me know.