### PR TITLE
Fix build in emscripten 3.1.0

### DIFF
--- a/bin/build_openssl_emscripten.sh
+++ b/bin/build_openssl_emscripten.sh
@@ -65,7 +65,7 @@ fi
 
 cd "$SRC_PATH"
 
-emcmake perl ./Configure \
+perl ./Configure \
 	linux-generic32 \
 	-no-asm no-ssl2 no-ssl3 no-comp no-engine no-deprecated no-tests no-dso no-shared no-threads disable-shared \
 	--prefix="$INSTALL_PATH" \


### PR DESCRIPTION
Emcmake is for Python, see https://github.com/emscripten-core/emscripten/blob/main/emcmake

Wrapping a perl command with emcmake fails.