### PR TITLE
fix: inject WASM globals for proxyToWorker=false in Node.js

### DIFF
--- a/src/main/ts/common/LibraryUtils.ts
+++ b/src/main/ts/common/LibraryUtils.ts
@@ -282,6 +282,12 @@ export default class LibraryUtils {
   protected static initWasmModule(wasmModule) {
     wasmModule.taskQueue = new ThreadPool(1);
     wasmModule.queueTask = async function(asyncFn) { return wasmModule.taskQueue.submit(asyncFn); }
+    if (!GenUtils.isBrowser()) {
+      const HttpClient = require("./HttpClient").default;
+      (globalThis as any).HttpClient = HttpClient;
+      (globalThis as any).LibraryUtils = LibraryUtils;
+      (globalThis as any).GenUtils = GenUtils;
+    }
   }
   
   protected static prefixWindowsPath(path) {


### PR DESCRIPTION
## Summary

- When using `MoneroWalletFull` with `proxyToWorker: false` in Node.js, EM_JS functions (`js_send_json_request`, `js_send_binary_request`) access `HttpClient`, `LibraryUtils`, and `GenUtils` via `this`, which resolves to `globalThis`
- In the browser web worker path, these are set via `self.HttpClient = HttpClient` in `MoneroWebWorker.ts`
- In Node.js without a worker proxy, they are never set, causing `TypeError: Cannot read properties of undefined (reading 'request')` on any RPC call
- This fix injects the required globals in `initWasmModule()` for non-browser environments

## Test plan

- [ ] Create a wallet with `proxyToWorker: false` in Node.js
- [ ] Verify wallet creation, sync, and transfer all work without the web worker
- [ ] Verify browser behavior is unchanged (guard: `!GenUtils.isBrowser()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)