### PR TITLE
fix: use standard npm repository object in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "description": "A TypeScript library for using Monero",
   "version": "0.11.10",
   "license": "MIT",
-  "repository": "https://github.com/woodser/monero-ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/woodser/monero-ts.git"
+  },
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Problem

`package.json` sets `repository` to a plain URL string:
```json
"repository": "https://github.com/woodser/monero-ts"
```

`publint` warns this is not a valid shorthand value supported by npm:
```
pkg.repository is https://github.com/woodser/monero-ts which isn't a valid
shorthand value supported by npm. Consider using an object that references a repository.
```

**Reproduction:**
```shell
npm pack monero-javascript@0.8.4 --silent >/dev/null
npx publint@0.3.21 run monero-javascript-0.8.4.tgz --level warning
```

## Fix

Change `repository` from a plain string to the standard npm object form:

```diff
-"repository": "https://github.com/woodser/monero-ts",
+"repository": {
+  "type": "git",
+  "url": "git+https://github.com/woodser/monero-ts.git"
+},
```

No runtime behaviour is changed — metadata only.