### PR TITLE
wallet: support explicit trusted daemon for full wallets

### DIFF
--- a/src/main/cpp/index.cpp
+++ b/src/main/cpp/index.cpp
@@ -33,6 +33,7 @@ EMSCRIPTEN_BINDINGS(module)
   emscripten::function("is_view_only", &monero_wasm_bridge::is_view_only);
   emscripten::function("set_daemon_connection", &monero_wasm_bridge::set_daemon_connection);
   emscripten::function("get_daemon_connection", &monero_wasm_bridge::get_daemon_connection);
+  emscripten::function("is_daemon_trusted", &monero_wasm_bridge::is_daemon_trusted);
   emscripten::function("is_connected_to_daemon", &monero_wasm_bridge::is_connected_to_daemon);
   emscripten::function("get_daemon_max_peer_height", &monero_wasm_bridge::get_daemon_max_peer_height);
   emscripten::function("get_version", &monero_wasm_bridge::get_version);

--- a/src/main/cpp/monero_wasm_bridge.cpp
+++ b/src/main/cpp/monero_wasm_bridge.cpp
@@ -248,9 +248,9 @@ bool monero_wasm_bridge::is_view_only(int handle) {
   return wallet->is_view_only();
 }
 
-void monero_wasm_bridge::set_daemon_connection(int handle, const string& uri, const string& username, const string& password, const string& proxy_uri, emscripten::val callback) {
+void monero_wasm_bridge::set_daemon_connection(int handle, const string& uri, const string& username, const string& password, const string& proxy_uri, int is_trusted, emscripten::val callback) {
   monero_wallet* wallet = (monero_wallet*) handle;
-  wallet->set_daemon_connection(uri, username, password, proxy_uri);
+  wallet->set_daemon_connection(uri, username, password, proxy_uri, is_trusted < 0 ? boost::none : boost::optional<bool>(is_trusted != 0)); // trusted is unset if negative
   callback();
 }
 
@@ -258,6 +258,11 @@ string monero_wasm_bridge::get_daemon_connection(int handle) {
   monero_wallet* wallet = (monero_wallet*) handle;
   boost::optional<monero_rpc_connection> daemon_connection = wallet->get_daemon_connection();
   return daemon_connection == boost::none ? "" : daemon_connection.get().serialize();
+}
+
+bool monero_wasm_bridge::is_daemon_trusted(int handle) {
+  monero_wallet* wallet = (monero_wallet*) handle;
+  return wallet->is_daemon_trusted();
 }
 
 void monero_wasm_bridge::is_connected_to_daemon(int handle, emscripten::val callback) {

--- a/src/main/cpp/monero_wasm_bridge.h
+++ b/src/main/cpp/monero_wasm_bridge.h
@@ -44,8 +44,9 @@ namespace monero_wasm_bridge
   // ----------------------- WALLET INSTANCE METHODS --------------------------
 
   bool is_view_only(int handle);
-  void set_daemon_connection(int handle, const string& uri, const string& username, const string& password, const string& proxy_uri, emscripten::val callback);
+  void set_daemon_connection(int handle, const string& uri, const string& username, const string& password, const string& proxy_uri, int is_trusted, emscripten::val callback);
   string get_daemon_connection(int handle);
+  bool is_daemon_trusted(int handle);
   void is_connected_to_daemon(int handle, emscripten::val callback);
   void get_daemon_max_peer_height(int handle, emscripten::val callback);
   string get_version(int handle);

--- a/src/main/ts/common/MoneroWebWorker.ts
+++ b/src/main/ts/common/MoneroWebWorker.ts
@@ -509,13 +509,17 @@ self.decodeIntegratedAddress = async function(walletId, integratedAddress) {
   return (await self.WORKER_OBJECTS[walletId].decodeIntegratedAddress(integratedAddress)).toJson();
 }
 
-self.setDaemonConnection = async function(walletId, config) {
-  return self.WORKER_OBJECTS[walletId].setDaemonConnection(config ? new MoneroRpcConnection(Object.assign(config, {proxyToWorker: false})) : undefined);
+self.setDaemonConnection = async function(walletId, config, isTrusted) {
+  return self.WORKER_OBJECTS[walletId].setDaemonConnection(config ? new MoneroRpcConnection(Object.assign(config, {proxyToWorker: false})) : undefined, isTrusted);
 }
 
 self.getDaemonConnection = async function(walletId) {
   let connection = await self.WORKER_OBJECTS[walletId].getDaemonConnection();
   return connection ? connection.getConfig() : undefined;
+}
+
+self.isDaemonTrusted = async function(walletId) {
+  return self.WORKER_OBJECTS[walletId].isDaemonTrusted();
 }
 
 self.isConnectedToDaemon = async function(walletId) {

--- a/src/main/ts/wallet/MoneroWallet.ts
+++ b/src/main/ts/wallet/MoneroWallet.ts
@@ -128,9 +128,10 @@ export default class MoneroWallet {
    * Set the wallet's daemon connection.
    * 
    * @param {MoneroRpcConnection | string} [uriOrConnection] - daemon's URI or connection (defaults to offline)
+   * @param {boolean} [isTrusted] - indicates if the daemon is trusted (defaults to trusted if local address)
    * @return {Promise<void>}
    */
-  async setDaemonConnection(uriOrConnection?: Partial<MoneroRpcConnection> | string): Promise<void> {
+  async setDaemonConnection(uriOrConnection?: Partial<MoneroRpcConnection> | string, isTrusted?: boolean): Promise<void> {
     throw new MoneroError("Not supported");
   }
   

--- a/src/main/ts/wallet/MoneroWalletFull.ts
+++ b/src/main/ts/wallet/MoneroWalletFull.ts
@@ -145,6 +145,9 @@ export default class MoneroWalletFull extends MoneroWalletKeys {
     // open wallet from data
     const wallet = await MoneroWalletFull.openWalletData(config);
 
+    // apply explicit daemon trust
+    if (config.getIsTrustedDaemon() !== undefined && config.getServer()) await wallet.setDaemonConnection(config.getServer(), config.getIsTrustedDaemon());
+
     // set connection manager
     await wallet.setConnectionManager(config.getConnectionManager());
     return wallet;
@@ -433,8 +436,8 @@ export default class MoneroWalletFull extends MoneroWalletKeys {
     return super.getListeners();
   }
   
-  async setDaemonConnection(uriOrConnection?: Partial<MoneroRpcConnection> | string): Promise<void> {
-    if (this.getWalletProxy()) return this.getWalletProxy().setDaemonConnection(uriOrConnection);
+  async setDaemonConnection(uriOrConnection?: Partial<MoneroRpcConnection> | string, isTrusted?: boolean): Promise<void> {
+    if (this.getWalletProxy()) return this.getWalletProxy().setDaemonConnection(uriOrConnection, isTrusted);
 
     // normalize connection
     let connection = !uriOrConnection ? undefined : uriOrConnection instanceof MoneroRpcConnection ? uriOrConnection : new MoneroRpcConnection(uriOrConnection);
@@ -443,19 +446,33 @@ export default class MoneroWalletFull extends MoneroWalletKeys {
     let password = connection && connection.getPassword() ? connection.getPassword() : "";
     let proxyUri = connection && connection.getProxyUri() ? connection.getProxyUri() : "";
     let rejectUnauthorized = connection ? connection.getRejectUnauthorized() : undefined;
+    let isTrustedArg = isTrusted === undefined ? -1 : (isTrusted ? 1 : 0); // negative if unset
     this.rejectUnauthorized = rejectUnauthorized;  // persist locally
-    
+
     // set connection in queue
     return this.module.queueTask(async () => {
       this.assertNotClosed();
       return new Promise<void>((resolve, reject) => {
-        this.module.set_daemon_connection(this.cppAddress, uri, username, password, proxyUri, (resp) => {
+        this.module.set_daemon_connection(this.cppAddress, uri, username, password, proxyUri, isTrustedArg, (resp) => {
           resolve();
         });
       });
     });
   }
-  
+
+  /**
+   * Indicates if the wallet's daemon is trusted.
+   *
+   * @return {Promise<boolean>} true if the daemon is trusted, false otherwise
+   */
+  async isDaemonTrusted(): Promise<boolean> {
+    if (this.getWalletProxy()) return this.getWalletProxy().isDaemonTrusted();
+    return this.module.queueTask(async () => {
+      this.assertNotClosed();
+      return this.module.is_daemon_trusted(this.cppAddress);
+    });
+  }
+
   async getDaemonConnection(): Promise<MoneroRpcConnection> {
     if (this.getWalletProxy()) return this.getWalletProxy().getDaemonConnection();
     return this.module.queueTask(async () => {
@@ -1910,14 +1927,18 @@ class MoneroWalletFullProxy extends MoneroWalletKeysProxy {
     return this.invokeWorker("setSubaddressLabel", Array.from(arguments)) as Promise<void>;
   }
   
-  async setDaemonConnection(uriOrRpcConnection) {
-    if (!uriOrRpcConnection) await this.invokeWorker("setDaemonConnection");
+  async setDaemonConnection(uriOrRpcConnection, isTrusted?) {
+    if (!uriOrRpcConnection) await this.invokeWorker("setDaemonConnection", [undefined, isTrusted]);
     else {
       let connection = !uriOrRpcConnection ? undefined : uriOrRpcConnection instanceof MoneroRpcConnection ? uriOrRpcConnection : new MoneroRpcConnection(uriOrRpcConnection);
-      await this.invokeWorker("setDaemonConnection", connection ? connection.getConfig() : undefined);
+      await this.invokeWorker("setDaemonConnection", [connection ? connection.getConfig() : undefined, isTrusted]);
     }
   }
-  
+
+  async isDaemonTrusted() {
+    return this.invokeWorker("isDaemonTrusted") as Promise<boolean>;
+  }
+
   async getDaemonConnection() {
     let rpcConfig = await this.invokeWorker("getDaemonConnection");
     return rpcConfig ? new MoneroRpcConnection(rpcConfig) : undefined;

--- a/src/main/ts/wallet/model/MoneroWalletConfig.ts
+++ b/src/main/ts/wallet/model/MoneroWalletConfig.ts
@@ -20,6 +20,9 @@ export default class MoneroWalletConfig {
   /** Server config to monerod or monero-wallet-rpc. */
   server: string | Partial<MoneroRpcConnection>;
 
+  /** Indicates if the server is trusted (defaults to trusted if local address). */
+  isTrustedDaemon: boolean;
+
   /** Govern the wallet's server connection. */
   connectionManager: MoneroConnectionManager;
 
@@ -92,6 +95,7 @@ export default class MoneroWalletConfig {
    * @param {number} [config.accountLookahead] -  number of accounts to scan (optional)
    * @param {number} [config.subaddressLookahead] - number of subaddresses to scan per account (optional)
    * @param {string|Partial<MoneroRpcConnection>} [config.server] - uri or MoneroRpcConnection to the wallet's server (optional)
+   * @param {boolean} [config.isTrustedDaemon] - indicates if the server is trusted (defaults to trusted if local address)
    * @param {MoneroConnectionManager} [config.connectionManager] - manage connections to monerod (optional)
    * @param {boolean} [config.rejectUnauthorized] - reject self-signed server certificates if true (default true)
    * @param {Uint8Array} [config.keysData] - wallet keys data to open (optional)
@@ -162,6 +166,15 @@ export default class MoneroWalletConfig {
     return this;
   }
   
+  getIsTrustedDaemon(): boolean {
+    return this.isTrustedDaemon;
+  }
+
+  setIsTrustedDaemon(isTrustedDaemon: boolean): MoneroWalletConfig {
+    this.isTrustedDaemon = isTrustedDaemon;
+    return this;
+  }
+
   getConnectionManager(): MoneroConnectionManager {
     return this.connectionManager;
   }


### PR DESCRIPTION
Adds setDaemonConnection(connection, isTrusted) to MoneroWallet, wallet config support, and isDaemonTrusted() for full wallets.